### PR TITLE
update: tokenize input with struct

### DIFF
--- a/9cc.c
+++ b/9cc.c
@@ -1,5 +1,131 @@
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
+// NOTE: enum は定数を一括で宣言できる型
+typedef enum
+{
+  TK_RESERVED, // 記号
+  TK_NUM,      // 整数トークン
+  TK_EOF       // 入力の終わりを表すトークン
+} TokenKind;
+
+/*
+  NOTE: typedef で struct Token を通常の名前空間で変数宣言できるようにする
+        struct Token { ... };
+        struct Token token; => OK
+        Token token; => Error
+        typedef struct Token token_t;
+        token_t token; => OK
+*/
+typedef struct Token Token;
+
+struct Token
+{
+  TokenKind kind; // トークンの型
+  Token *next;    // 次の入力トークン
+  int val;        // kindがTK_NUMの場合、その数値
+  char *str;      // トークン文字列
+};
+
+// 現在着目しているトークン
+Token *token;
+
+// エラーを報告するための関数
+// printfと同じ引数を取る
+// NOTE: ... は引数がいくつあってもよいという意味。
+//       int main() === int main(...) != int main(void)
+void error(char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  vfprintf(stderr, fmt, ap);
+  fprintf(stderr, "\n");
+  exit(1);
+}
+
+// 次のトークンが期待している記号のときには、トークンを1つ読み進めて
+// 真を返す。それ以外の場合には偽を返す。
+bool consume(char op)
+{
+  if (token->kind != TK_RESERVED || token->str[0] != op)
+    return false;
+  token = token->next;
+  return true;
+}
+
+// 次のトークンが期待している記号のときには、トークンを1つ読み進める。
+// それ以外の場合にはエラーを報告する。
+void expect(char op)
+{
+  if (token->kind != TK_RESERVED || token->str[0] != op)
+    error("'%c'ではありません", op);
+  token = token->next;
+}
+
+// 次のトークンが数値の場合、トークンを1つ読み進めてその数値を返す。
+// それ以外の場合にはエラーを報告する。
+int expect_number(void)
+{
+  if (token->kind != TK_NUM)
+    error("'%c'ではありません");
+  int val = token->val;
+  token = token->next;
+  return val;
+}
+
+bool at_eof(void)
+{
+  return token->kind == TK_EOF;
+}
+
+Token *new_token(TokenKind kind, Token *cur, char *str)
+{
+  Token *tok = calloc(1, sizeof(Token));
+  tok->kind = kind;
+  tok->str = str;
+  cur->next = tok;
+  return tok;
+}
+
+// 入力文字列pをトークナイズしてそれを返す
+Token *tokenize(char *p)
+{
+  Token head;
+  head.next = NULL;
+  Token *cur = &head;
+
+  while (*p)
+  {
+    // 空文字はスキップ
+    if (isspace(*p))
+    {
+      p++;
+      continue;
+    }
+
+    if (*p == '+' || *p == '-')
+    {
+      cur = new_token(TK_RESERVED, cur, p++);
+      continue;
+    }
+
+    if (isdigit(*p))
+    {
+      cur = new_token(TK_NUM, cur, p);
+      cur->val = strtol(p, &p, 10);
+      continue;
+    }
+
+    error("トークナイズできません");
+  }
+
+  new_token(TK_EOF, cur, p);
+  return head.next;
+}
 
 int main(int argc, char **argv)
 {
@@ -9,31 +135,29 @@ int main(int argc, char **argv)
     return 1;
   }
 
-  char *p = argv[1];
+  // トークナイズする
+  token = tokenize(argv[1]);
 
   printf(".intel_syntax noprefix\n");
   printf(".global main\n");
   printf("main:\n");
-  printf("  mov rax, %ld\n", strtol(p, &p, 10));
 
-  while (*p)
+  // 式の最初は数でなければならないので、それをチェックして
+  // 最初のmov命令を出力
+  printf("  mov rax, %d\n", expect_number());
+
+  // `+ <数>`あるいは`- <数>`というトークンの並びを消費しつつ
+  // アセンブリを出力
+  while (!at_eof())
   {
-    if (*p == '+')
+    if (consume('+'))
     {
-      p++;
-      printf("  add rax, %ld\n", strtol(p, &p, 10));
+      printf("  add rax, %d\n", expect_number());
       continue;
     }
 
-    if (*p == '-')
-    {
-      p++;
-      printf("  sub rax, %ld\n", strtol(p, &p, 10));
-      continue;
-    }
-
-    fprintf(stderr, "予期しない文字です: '%c'\n", *p);
-    return 1;
+    expect('-');
+    printf("  sub rax, %d\n", expect_number());
   }
 
   printf("  ret\n");

--- a/test.sh
+++ b/test.sh
@@ -21,5 +21,6 @@ try 0 0
 try 42 42
 try 2 1+1
 try 51 5-21+67
+try 233 '10 - 34 + 1'
 
 echo OK


### PR DESCRIPTION
## summary
- typedef enum TokenKind to label token type: TK_RESERVED, TK_NUM, TK_EOF.
- create struct Token for input
- typedef Token to ordinary name space.
- create tokenize function to divide input into unary expressions.

## tips
- There are a couple of name spaces in C: Tag name space, Member name space, Ordinary name space.
When declaring identifiers, certain keyword is required for its type (e.g. `enum kind = ...` `struct Token token`). But when typedef'd into ordinary name space, they can be declared without those keywords.

```c
enum color { RED, GREEN, BLUE};
enum color r = RED; // OK
// color x = GREEN: // Error: color is not in ordinary name space
typedef enum color color_t;
color_t x = GREEN; // OK
```

-  `int main() == int main(...) != int main(void)`. When you need to make functions with no arguments permitted, use `void`.