### PR TITLE
Support multi letter local variables

### DIFF
--- a/9cc.h
+++ b/9cc.h
@@ -40,6 +40,7 @@ void error_at(char *loc, char *fmt, ...);
 void error(char *fmt, ...);
 Token *new_token(TokenKind kind, Token *cur, char *str, int len);
 bool start_with(char *lhs, char *rhs);
+bool is_alpha(char c);
 Token *tokenize();
 
 /* parse.c */
@@ -70,6 +71,7 @@ struct Node
 };
 
 bool consume(char *op);
+Token *consume_ident(void);
 void expect(char *op);
 int expect_number(void);
 bool at_eof(void);
@@ -99,6 +101,19 @@ Node *add();
 Node *mul();
 Node *unary();
 Node *primary();
+
+typedef struct LVar LVar;
+
+struct LVar
+{
+  LVar *next;
+  char *name;
+  int len;
+  int offset;
+};
+
+LVar *locals;
+LVar *find_lvar(Token *token);
 
 /* codegen.c */
 

--- a/main.c
+++ b/main.c
@@ -8,6 +8,7 @@ int main(int argc, char **argv)
   user_input = argv[1];
   // トークナイズする
   token = tokenize();
+  locals = calloc(1, sizeof(LVar));
   program();
   printf(".intel_syntax noprefix\n");
   printf(".global main\n");
@@ -15,7 +16,7 @@ int main(int argc, char **argv)
 
   printf("  push rbp\n");
   printf("  mov rbp, rsp\n");
-  printf("  sub rsp, 208\n");
+  printf("  sub rsp, %d\n", locals->offset);
 
   for (size_t i = 0; code[i]; i++)
   {

--- a/test.sh
+++ b/test.sh
@@ -44,5 +44,7 @@ try 1 '3 >= 3;'
 try 1 '5 >= 3;'
 
 try 29 'a=3+4;b=5*6-8;a+b;'
+try 8 'foo=3;bar=5;foo+bar;'
+try 58 'foo = 3 * 20 - (6 / 2); bar = 45 >= 10; foo + bar;'
 
 echo OK

--- a/tokenize.c
+++ b/tokenize.c
@@ -41,6 +41,11 @@ bool start_with(char *lhs, char *rhs)
   return memcmp(lhs, rhs, strlen(rhs)) == 0;
 }
 
+bool is_alpha(char c)
+{
+  return ('a' <= c && c <= 'z');
+}
+
 // 入力文字列user_inputをトークナイズしてそれを返す
 Token *tokenize()
 {
@@ -73,10 +78,13 @@ Token *tokenize()
       continue;
     }
 
-    if ('a' <= *p && *p <= 'z')
+    // multi-letter identifier
+    if (is_alpha(*p))
     {
-      cur = new_token(TK_IDENT, cur, p++, 0);
-      cur->len = 1;
+      char *q = p++;
+      while (is_alpha(*p))
+        p++;
+      cur = new_token(TK_IDENT, cur, q, p - q);
       continue;
     }
 


### PR DESCRIPTION
## summary
- create another struct `LVar` to store all the locals variables.
- tokenize multi letter identifier by looping `is_alpha(char c)` with user input.
- allocate memories for local variables by referencing LVar's offset.

## how Assembly allocates memories for local variables

```assembly
$ ./9cc "foo;bar;baz;"
.intel_syntax noprefix
.global main
main:
  push rbp
  mov rbp, rsp
  sub rsp, 24 ; subtract 24 bytes from stack pointer, which is referenced by the offset value of `locals`'s first struct.
  mov rax, rbp
  sub rax, 8
  push rax
  pop rax
  mov rax, [rax]
  push rax
  pop rax
  mov rax, rbp
  sub rax, 16
  push rax
  pop rax
  mov rax, [rax]
  push rax
  pop rax
  mov rax, rbp
  sub rax, 24
  push rax
  pop rax
  mov rax, [rax]
  push rax
  pop rax
  mov rsp, rbp
  pop rbp
  ret
```

## ref
https://www.sigbus.info/compilerbook#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710%E8%A4%87%E6%95%B0%E6%96%87%E5%AD%97%E3%81%AE%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E5%A4%89%E6%95%B0