### PR TITLE
Support return keyword

### DIFF
--- a/9cc.h
+++ b/9cc.h
@@ -11,6 +11,7 @@
 typedef enum
 {
   TK_RESERVED, // 記号
+  TK_RETURN,   // return
   TK_IDENT,    // 識別子
   TK_NUM,      // 整数トークン
   TK_EOF       // 入力の終わりを表すトークン
@@ -57,7 +58,8 @@ typedef enum
   ND_MUL,    // *
   ND_DIV,    // /
   ND_LVAR,   // ローカル変数
-  ND_NUM     // Integer
+  ND_NUM,    // Integer
+  ND_RETURN  // return keyword
 } NodeKind;
 
 typedef struct Node Node;
@@ -81,7 +83,7 @@ Node *new_node_num(int val);
 
 // NODE: 四則演算, 比較表現, 変数は以下で表現される。これをC関数に落とし込む。
 //       program = stmt*
-//       stmt    = expr ";"
+//       stmt    = expr ";" | return expr ";"
 //       expr    = assign
 //       assign  = equality ("=" assign)?
 //       equality = relational ("==" relational | "!=" relational)*

--- a/codegen.c
+++ b/codegen.c
@@ -14,6 +14,12 @@ void gen(Node *node)
 {
   switch (node->kind)
   {
+  case ND_RETURN:
+    gen(node->lhs);
+    printf("  mov rsp, rbp\n");
+    printf("  pop rbp\n");
+    printf("  ret\n");
+    return;
   case ND_NUM:
     printf("  push %d\n", node->val);
     return;

--- a/parse.c
+++ b/parse.c
@@ -21,6 +21,14 @@ Token *consume_ident(void)
   return tok;
 }
 
+bool consume_return(void)
+{
+  if (token->kind != TK_RETURN)
+    return false;
+  token = token->next;
+  return true;
+}
+
 // 次のトークンが期待している記号のときには、トークンを1つ読み進める。
 // それ以外の場合にはエラーを報告する。
 void expect(char *op)
@@ -90,7 +98,14 @@ void *program()
 
 Node *stmt()
 {
-  Node *node = expr();
+  Node *node;
+  if (consume_return())
+  {
+    node = new_node(ND_RETURN);
+    node->lhs = expr();
+  }
+  else
+    node = expr();
   expect(";");
   return node;
 }

--- a/test.sh
+++ b/test.sh
@@ -46,5 +46,6 @@ try 1 '5 >= 3;'
 try 29 'a=3+4;b=5*6-8;a+b;'
 try 8 'foo=3;bar=5;foo+bar;'
 try 58 'foo = 3 * 20 - (6 / 2); bar = 45 >= 10; foo + bar;'
+try 5 'foo = 5;return foo;'
 
 echo OK

--- a/tokenize.c
+++ b/tokenize.c
@@ -43,10 +43,21 @@ bool start_with(char *lhs, char *rhs)
 
 bool is_alpha(char c)
 {
-  return ('a' <= c && c <= 'z');
+  return ('a' <= c && c <= 'z') ||
+         ('A' <= c && c <= 'Z');
 }
 
-// 入力文字列user_inputをトークナイズしてそれを返す
+bool is_alnum(char c)
+{
+  return is_alpha(c) && ('0' <= c && c <= '9') || ('_' == c);
+}
+
+bool is_return(char *op)
+{
+  return (memcmp(op, "return", 6) == 0 && !is_alnum(op[6]));
+}
+
+//a 入力文字列user_inputをトークナイズしてそれを返す
 Token *tokenize()
 {
   char *p = user_input;
@@ -75,6 +86,14 @@ Token *tokenize()
     if (strchr("+-*/()<>;=", *p))
     {
       cur = new_token(TK_RESERVED, cur, p++, 1);
+      continue;
+    }
+
+    // return keyword
+    if (is_return(p))
+    {
+      cur = new_token(TK_RETURN, cur, p, 6);
+      p += 6;
       continue;
     }
 


### PR DESCRIPTION
## summary
- support `return` keyword.
- add `TK_RETURN` in TokenKind, `ND_RETURN` in NodeKind.

For now, instruction sets would be doubled at the end when `return` used.
```assembly
$ ./9cc "foo = 1;return foo;"
.intel_syntax noprefix
.global main
main:
  push rbp
  mov rbp, rsp
  sub rsp, 8
  mov rax, rbp
  sub rax, 8
  push rax
  push 1
  pop rdi
  pop rax
  mov [rax], rdi
  push rdi
  pop rax
  mov rax, rbp
  sub rax, 8
  push rax
  pop rax
  mov rax, [rax]
  push rax
  mov rsp, rbp
  pop rbp
  ret
  pop rax
  mov rsp, rbp
  pop rbp
  ret
```

## ref
https://www.sigbus.info/compilerbook#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711return%E6%96%87