### PR TITLE
feat: add while condition

### DIFF
--- a/9cc.h
+++ b/9cc.h
@@ -59,7 +59,8 @@ typedef enum
   ND_LVAR,   // ローカル変数
   ND_NUM,    // Integer
   ND_RETURN, // return keyword
-  ND_IF      // if keyword
+  ND_IF,     // if keyword
+  ND_WHILE   // while keyword
 } NodeKind;
 
 typedef struct Node Node;
@@ -89,6 +90,7 @@ Node *new_node_num(int val);
 //       stmt    = expr ";"
 //                 | return expr ";"
 //                 | "if" "(" expr ")" stmt ("else" stmt)?
+//                 | "while" "(" expr ")" stmt
 //       expr    = assign
 //       assign  = equality ("=" assign)?
 //       equality = relational ("==" relational | "!=" relational)*

--- a/codegen.c
+++ b/codegen.c
@@ -40,6 +40,19 @@ void gen(Node *node)
     }
     return;
   }
+  case ND_WHILE:
+  {
+    int seq = labelseq++;
+    printf(".L.continue.%d:\n", seq);
+    gen(node->cond);
+    printf("  pop rax\n");
+    printf("  cmp rax, 0\n");
+    printf("  je .L.break.%d\n", seq);
+    gen(node->then);
+    printf("  jmp .L.continue.%d\n", seq);
+    printf(".L.break.%d:\n", seq);
+    return;
+  }
   case ND_RETURN:
     gen(node->lhs);
     printf("  pop rax\n");

--- a/parse.c
+++ b/parse.c
@@ -113,6 +113,16 @@ Node *stmt()
     }
     return node;
   }
+  else if (consume("while"))
+  {
+    node = new_node(ND_WHILE);
+    expect("(");
+    node->cond = expr();
+    expect(")");
+    expect("{");
+    node->then = stmt();
+    expect("}");
+  }
   else
     node = expr();
   expect(";");

--- a/test.sh
+++ b/test.sh
@@ -53,4 +53,6 @@ try 1 'if (10 >= 5) { return 1; } else { return 2; }'
 try 1 'if (10 >= 5) { 1; } else { 2; }'
 try 2 'foo = 10; if (foo < 5) { bar = 1; } else { bar = 2; } return bar;'
 
+try 10 'count = 0; while (count < 10) { count = count + 1; }; count;'
+
 echo OK

--- a/tokenize.c
+++ b/tokenize.c
@@ -54,7 +54,7 @@ bool is_alnum(char c)
 
 char *starts_with_reserved(char *p)
 {
-  char *kw[] = {"if", "else", "return"};
+  char *kw[] = {"if", "else", "return", "while"};
   int kw_size = sizeof(kw) / sizeof(kw[0]);
   for (size_t i = 0; i < kw_size; i++)
   {


### PR DESCRIPTION
## summary
- add `while` to the array in `starts_with_reserved` function.
- add ND_WHILE kind to Node struct.

## how Assembly interpret while condition
```assembly
$ ./9cc 'count = 0; while (count < 10) { count = count + 1; }; count;'
.intel_syntax noprefix
.global main
main:
  push rbp
  mov rbp, rsp
  sub rsp, 8
  mov rax, rbp
  sub rax, 8
  push rax
  push 0
  pop rdi
  pop rax
  mov [rax], rdi
  push rdi
  pop rax
.L.continue.1:
  mov rax, rbp
  sub rax, 8
  push rax
  pop rax
  mov rax, [rax]
  push rax
  push 10
  pop rdi
  pop rax
  cmp rax, rdi
  setl al
  movzb rax, al
  push rax
  pop rax
  cmp rax, 0
  je .L.break.1
  mov rax, rbp
  sub rax, 8
  push rax
  mov rax, rbp
  sub rax, 8
  push rax
  pop rax
  mov rax, [rax]
  push rax
  push 1
  pop rdi
  pop rax
  add rax, rdi
  push rax
  pop rdi
  pop rax
  mov [rax], rdi
  push rdi
  jmp .L.continue.1
.L.break.1:
  pop rax
  mov rax, rbp
  sub rax, 8
  push rax
  pop rax
  mov rax, [rax]
  push rax
  pop rax
  jmp .L.return.main
.L.return.main:
  mov rsp, rbp
  pop rbp
  ret
```

## ref
https://www.sigbus.info/compilerbook#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9712-%E5%88%B6%E5%BE%A1%E6%A7%8B%E6%96%87%E3%82%92%E8%B6%B3%E3%81%99