### PR TITLE
update: align stack frame to 16 bytes boundary to meet ABI

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -94,7 +94,22 @@ void gen(Node *node)
     for (int i = nargs - 1; i >= 0; i--)
       printf("  pop %s\n", argreg[i]);
 
+    // We need to align RSP to a 16 byte boundary before
+    // calling a function to meet ABI requirement.
+    // RAX is set to 0 for variadic function.
+    int seq = labelseq++;
+    printf("  mov rax, rsp\n");
+    printf("  and rax, 15\n");
+    printf("  jnz .L.call.%d\n", seq);
+    printf("  mov rax, 0\n");
     printf("  call %s\n", node->funcname);
+    printf("  jmp .L.end.%d\n", seq);
+    printf(".L.call.%d:\n", seq);
+    printf("  sub rsp, 8\n");
+    printf("  mov rax, 0\n");
+    printf("  call %s\n", node->funcname);
+    printf("  add rsp, 8\n");
+    printf(".L.end.%d:\n", seq);
     printf("  push rax\n");
     return;
   }


### PR DESCRIPTION
## summary
- align RSP(or stack pointer) to a 16 bytes boundary before calling a function to meet ABI requirement.

## detail
- `and rax, 15` does AND operation between the current stack and 16 bytes, and returns 1 if the stack is 16 byte boundary, otherwise returns 0.
- `jnz .L.call.%d` calls the function if the result of the previous operation (which is `and rax, 15`) returns 1, or not zero as `jnz` means "jump if not zero".

## ref
- https://github.com/rui314/chibicc/commit/ee423036ed953e5d29a6edc016cf80363e0385ba