### PR TITLE
Show Token for Node in error message

### DIFF
--- a/9cc.h
+++ b/9cc.h
@@ -36,8 +36,9 @@ struct Token
 };
 
 Token *token;
-void error_at(char *loc, char *fmt, ...);
 void error(char *fmt, ...);
+void error_at(char *loc, char *fmt, ...);
+void error_tok(Token *tok, char *fmt, ...);
 Token *new_token(TokenKind kind, Token *cur, char *str, int len);
 bool start_with(char *lhs, char *rhs);
 bool is_alpha(char c);
@@ -93,6 +94,7 @@ struct Node
 
   Node *body; // statements in block
   Node *next; // next node
+  Token *tok;
 
   // function call
   char *funcname;
@@ -102,15 +104,15 @@ struct Node
   LVar *var; // ND_LVARの時のみ使い、変数に関する情報を格納する
 };
 
-bool consume(char *op);
+Token *consume(char *op);
 Token *consume_ident(void);
 void expect(char *op);
 int expect_number(void);
 char *expect_ident(void);
 bool at_eof(void);
-Node *new_node(NodeKind kind);
-Node *new_binary(NodeKind kind, Node *lhs, Node *rhs);
-Node *new_node_num(int val);
+Node *new_node(NodeKind kind, Token *tok);
+Node *new_binary(NodeKind kind, Node *lhs, Node *rhs, Token *tok);
+Node *new_node_num(int val, Token *tok);
 
 // NODE: 四則演算, 比較表現, 変数は以下で表現される。これをC関数に落とし込む。
 //       program    = stmt*

--- a/codegen.c
+++ b/codegen.c
@@ -7,7 +7,7 @@ char *funcname;
 void gen_lvar(Node *node)
 {
   if (node->kind != ND_LVAR)
-    error("左辺値が変数ではありません");
+    error_tok(node->tok, "左辺値が変数ではありません");
   printf("  mov rax, rbp\n");
   printf("  sub rax, %d\n", node->var->offset);
   printf("  push rax\n");

--- a/tokenize.c
+++ b/tokenize.c
@@ -13,10 +13,8 @@ void error(char *fmt, ...)
   exit(1);
 }
 
-void error_at(char *loc, char *fmt, ...)
+void verror_at(char *loc, char *fmt, va_list ap)
 {
-  va_list ap;
-  va_start(ap, fmt);
   int pos = loc - user_input;
   fprintf(stderr, "%s\n", user_input);
   fprintf(stderr, "%*s", pos, "");
@@ -24,6 +22,20 @@ void error_at(char *loc, char *fmt, ...)
   vfprintf(stderr, fmt, ap);
   fprintf(stderr, "\n");
   exit(1);
+}
+
+void error_at(char *loc, char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  verror_at(loc, fmt, ap);
+}
+
+void error_tok(Token *tok, char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  verror_at(tok->str, fmt, ap);
 }
 
 Token *new_token(TokenKind kind, Token *cur, char *str, int len)


### PR DESCRIPTION
## summary
- add `error_tok` method to show Token in error message.
- add `tok` member to Node struct.

## ref
- https://github.com/rui314/chibicc/commit/01893a7ff1f954d215bd4597d560b8f8a651c63d