### PR TITLE
Support type int/pointer to int, and add/sub of num and pointer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 tmp*
 a.out
 9cc
+sample*

--- a/9cc.h
+++ b/9cc.h
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+typedef struct Type Type;
+
 /* tokenize.c */
 
 // NOTE: enum は定数を一括で宣言できる型
@@ -48,26 +50,29 @@ Token *tokenize();
 
 typedef enum
 {
-  ND_ASSIGN, // =
-  ND_EQ,     // ==
-  ND_NE,     // !=
-  ND_LE,     // <=
-  ND_LT,     // <
-  ND_ADD,    // +
-  ND_SUB,    // -
-  ND_MUL,    // *
-  ND_DIV,    // /
-  ND_ADDR,   // unary &
-  ND_DEREF,  // unary *
-  ND_LVAR,   // ローカル変数
-  ND_NUM,    // Integer
-  ND_RETURN, // return keyword
-  ND_IF,     // if keyword
-  ND_WHILE,  // while keyword
-  ND_FOR,    // for keyword
-  ND_BLOCK,  // block
-  ND_NULL,   // empty statement
-  ND_FUNCALL // function call
+  ND_ASSIGN,   // =
+  ND_EQ,       // ==
+  ND_NE,       // !=
+  ND_LE,       // <=
+  ND_LT,       // <
+  ND_ADD,      // num + num
+  ND_PTR_ADD,  // ptr + num || num + ptr
+  ND_SUB,      // num - num
+  ND_PTR_SUB,  // ptr - num || num - ptr
+  ND_PTR_DIFF, // ptr - ptr
+  ND_MUL,      // *
+  ND_DIV,      // /
+  ND_ADDR,     // unary &
+  ND_DEREF,    // unary *
+  ND_LVAR,     // ローカル変数
+  ND_NUM,      // Integer
+  ND_RETURN,   // return keyword
+  ND_IF,       // if keyword
+  ND_WHILE,    // while keyword
+  ND_FOR,      // for keyword
+  ND_BLOCK,    // block
+  ND_NULL,     // empty statement
+  ND_FUNCALL   // function call
 } NodeKind;
 
 typedef struct LVar LVar;
@@ -96,6 +101,7 @@ struct Node
 
   Node *body; // statements in block
   Node *next; // next node
+  Type *ty;   // Type, e.g. int, pointer to int
   Token *tok;
 
   // function call
@@ -147,20 +153,39 @@ struct Function
 };
 
 Function *program(void);
-void codegen();
+void codegen(Function *prog);
 Function *function(void);
-Node *stmt();
-Node *expr();
-Node *assign();
-Node *equality();
-Node *relational();
-Node *add();
-Node *mul();
-Node *unary();
-Node *primary();
+Node *stmt(void);
+Node *stmt2(void);
+Node *expr(void);
+Node *assign(void);
+Node *equality(void);
+Node *relational(void);
+Node *add(void);
+Node *mul(void);
+Node *unary(void);
+Node *primary(void);
 
 LVar *locals;
 LVar *find_lvar(Token *token);
+
+/* type.c */
+
+typedef enum
+{
+  TY_INT,
+  TY_PTR
+} TypeKind;
+
+struct Type
+{
+  TypeKind kind;
+  Type *base;
+};
+
+bool is_integer(Type *ty);
+Type *pointer_to(Type *base);
+void add_type(Node *node);
 
 /* codegen.c */
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS=-std=c11 -g -static
-SRCS=$(wildcard *c)
+SRCS=$(filter-out sample%, $(wildcard *c))
 OBJS=$(SRCS:.c=.o)
 
 9cc: $(OBJS)

--- a/codegen.c
+++ b/codegen.c
@@ -188,8 +188,22 @@ void gen(Node *node)
   case ND_ADD:
     printf("  add rax, rdi\n");
     break;
+  case ND_PTR_ADD:
+    printf("  imul rdi, 8\n");
+    printf("  add rax, rdi\n");
+    break;
   case ND_SUB:
     printf("  sub rax, rdi\n");
+    break;
+  case ND_PTR_SUB:
+    printf("  imul rdi, 8\n");
+    printf("  sub rax, rdi\n");
+    break;
+  case ND_PTR_DIFF:
+    printf("  sub rax, rdi\n");
+    printf("  cqo\n");
+    printf("  mov rdi, 8\n");
+    printf("  idiv rdi\n");
     break;
   case ND_MUL:
     printf("  imul rax, rdi\n");
@@ -199,7 +213,7 @@ void gen(Node *node)
     printf("  idiv rdi\n");
     break;
   default:
-    error("パースできません: node->kind: %d, node->str: %s\n", node->kind, node->val);
+    error_tok(node->tok, "No effective NodeKind found for the token");
   }
 
   printf("  push rax\n");

--- a/parse.c
+++ b/parse.c
@@ -135,7 +135,14 @@ Function *function(void)
   return fn;
 }
 
-Node *stmt()
+Node *stmt(void)
+{
+  Node *node = stmt2();
+  add_type(node);
+  return node;
+}
+
+Node *stmt2(void)
 {
   Node *node;
   Token *tok;
@@ -266,6 +273,34 @@ Node *relational()
   }
 }
 
+Node *new_add(Node *lhs, Node *rhs, Token *tok)
+{
+  add_type(lhs);
+  add_type(rhs);
+
+  if (is_integer(lhs->ty) && is_integer(rhs->ty))
+    return new_binary(ND_ADD, lhs, rhs, tok);
+  if (lhs->ty->base && is_integer(rhs->ty))
+    return new_binary(ND_PTR_ADD, lhs, rhs, tok);
+  if (is_integer(lhs->ty) && rhs->ty->base)
+    return new_binary(ND_ADD, rhs, lhs, tok);
+  error_tok(tok, "invalid operands");
+}
+
+Node *new_sub(Node *lhs, Node *rhs, Token *tok)
+{
+  add_type(lhs);
+  add_type(rhs);
+
+  if (is_integer(lhs->ty) && is_integer(rhs->ty))
+    return new_binary(ND_SUB, lhs, rhs, tok);
+  if (lhs->ty->base && is_integer(rhs->ty))
+    return new_binary(ND_PTR_SUB, lhs, rhs, tok);
+  if (lhs->ty->base && rhs->ty->base)
+    return new_binary(ND_PTR_DIFF, lhs, rhs, tok);
+  error_tok(tok, "invalid operands");
+}
+
 // add = mul ("+" mul | "-" mul)*
 Node *add()
 {
@@ -274,9 +309,9 @@ Node *add()
   for (;;)
   {
     if (tok = consume("+"))
-      node = new_binary(ND_ADD, node, mul(), tok);
+      node = new_add(node, mul(), tok);
     else if (tok = consume("-"))
-      node = new_binary(ND_SUB, node, mul(), tok);
+      node = new_sub(node, mul(), tok);
     else
       return node;
   }

--- a/test.sh
+++ b/test.sh
@@ -81,10 +81,11 @@ try 20 'main() { { 1 + 5; 4 * 5; }; }'
 
 try 3 'main() { x = 3; return *&x; }'
 try 5 'main() { x = 5; y = &x; z = &y; return **z; }'
-try 7 'main() { x = 4; y = 7; return *(&x + 8); }'
-try 3 'main() { x=3; y=5; return *(&y-8); }'
+try 7 'main() { x = 4; y = 7; return *(&x + 1); }'
+try 3 'main() { x=3; y=5; return *(&y-1); }'
 try 5 'main() { x=3; y=&x; *y=5; return x; }'
-try 7 'main() { x=3; y=5; *(&x+8)=7; return y; }'
-try 7 'main() { x=3; y=5; *(&y-8)=7; return x; }'
+try 7 'main() { x=3; y=5; *(&x+1)=7; return y; }'
+try 7 'main() { x=3; y=5; *(&y-1)=7; return x; }'
+try 2 'main() { x=3; return (&x+2)-&x; }'
 
 echo OK

--- a/type.c
+++ b/type.c
@@ -1,0 +1,67 @@
+#include "9cc.h"
+
+Type *int_type = &(Type){TY_INT};
+
+bool is_integer(Type *ty)
+{
+  return ty->kind == TY_INT;
+}
+
+Type *pointer_to(Type *base)
+{
+  Type *ty = calloc(1, sizeof(Type));
+  ty->kind = TY_PTR;
+  ty->base = base;
+  return ty;
+}
+
+void add_type(Node *node)
+{
+  if (!node || node->ty)
+    return;
+
+  add_type(node->lhs);
+  add_type(node->rhs);
+  add_type(node->cond);
+  add_type(node->then);
+  add_type(node->els);
+  add_type(node->init);
+  add_type(node->inc);
+
+  for (Node *n = node->body; n; n = n->next)
+    add_type(n);
+  for (Node *n = node->args; n; n = n->next)
+    add_type(n);
+
+  switch (node->kind)
+  {
+  case ND_ADD:
+  case ND_SUB:
+  case ND_PTR_DIFF:
+  case ND_MUL:
+  case ND_DIV:
+  case ND_EQ:
+  case ND_NE:
+  case ND_LT:
+  case ND_LE:
+  case ND_LVAR:
+  case ND_FUNCALL:
+  case ND_NUM:
+    node->ty = int_type;
+    return;
+  case ND_PTR_ADD:
+  case ND_PTR_SUB:
+  case ND_ASSIGN:
+    node->ty = node->lhs->ty;
+    return;
+  case ND_ADDR:
+    node->ty = pointer_to(node->lhs->ty);
+    return;
+  case ND_DEREF:
+    if (node->lhs->ty->kind == TY_PTR)
+      node->ty = node->lhs->ty->base;
+    else
+      node->ty = int_type;
+    return;
+  }
+}


### PR DESCRIPTION
## summary
- create `Type` struct and add to Node as member `ty`.
- create `TypeKind` enum for int/pointer to int.
- support add/sub between number +- number, pointer + number.
- ignore sample files on compile.

## tips
- `imul` executes signed multiply.
- `idiv` executes signed divide.
- `cqo` convert rax to sign-extend rax (64 bit mode only).

## ref
- https://github.com/rui314/chibicc/commit/a3ae40fc7fe70dd488a9f604f47d457ded9a6734
- https://www.sigbus.info/compilerbook#%E7%AC%A6%E5%8F%B7%E6%8B%A1%E5%BC%B5
- https://software.intel.com/sites/default/files/managed/39/c5/325462-sdm-vol-1-2abcd-3abcd.pdf
