### PR TITLE
add [] operator as an alias to pointer arithmetic

### DIFF
--- a/9cc.h
+++ b/9cc.h
@@ -180,6 +180,7 @@ Node *relational(void);
 Node *add(void);
 Node *mul(void);
 Node *unary(void);
+Node *postfix(void);
 Node *primary(void);
 
 LVarList *locals;

--- a/parse.c
+++ b/parse.c
@@ -377,7 +377,7 @@ Node *new_add(Node *lhs, Node *rhs, Token *tok)
   if (lhs->ty->base && is_integer(rhs->ty))
     return new_binary(ND_PTR_ADD, lhs, rhs, tok);
   if (is_integer(lhs->ty) && rhs->ty->base)
-    return new_binary(ND_ADD, rhs, lhs, tok);
+    return new_binary(ND_PTR_ADD, rhs, lhs, tok);
   error_tok(tok, "invalid operands");
 }
 
@@ -437,10 +437,10 @@ Node *unary()
     return new_unary(ND_ADDR, unary(), tok);
   if (tok = consume("*"))
     return new_unary(ND_DEREF, unary(), tok);
-  return primary();
+  return postfix();
 }
 
-Node *func_args()
+static Node *func_args()
 {
   if (consume(")"))
     return NULL;
@@ -454,6 +454,20 @@ Node *func_args()
   }
   expect(")");
   return head;
+}
+
+Node *postfix(void)
+{
+  Node *node = primary();
+  Token *tok;
+
+  while (tok = consume("["))
+  {
+    Node *exp = new_add(node, expr(), tok);
+    expect("]");
+    node = new_unary(ND_DEREF, exp, tok);
+  }
+  return node;
 }
 
 Node *primary()

--- a/test.sh
+++ b/test.sh
@@ -106,4 +106,19 @@ try 5 'int main() { int x[2][3]; int *y = x; *(y + 5) = 5; return *(*(x + 1) + 2
 try 6 'int main() { int x[2][3]; int *y = x; *(y + 6) = 6; return **(x + 2); }'
 try 10 'int main() { int x[2][2][2]; int *y = x; *(y + 1) = 10; return *(**x + 1); }'
 
+try 3 'int main() { int x[3]; *x=3; x[1]=4; x[2]=5; return *x; }'
+try 4 'int main() { int x[3]; *x=3; x[1]=4; x[2]=5; return *(x+1); }'
+try 5 'int main() { int x[3]; *x=3; x[1]=4; x[2]=5; return *(x+2); }'
+try 5 'int main() { int x[3]; *x=3; x[1]=4; x[2]=5; return *(x+2); }'
+try 5 'int main() { int x[3]; *x=3; x[1]=4; x[2]=5; return *(2+x); }'
+try 5 'int main() { int x[3]; *x=3; x[1]=4; 2[x]=5; return *(x+2); }'
+
+try 0 'int main() { int x[2][3]; int *y=x; y[0]=0; return x[0][0]; }'
+try 1 'int main() { int x[2][3]; int *y=x; y[1]=1; return x[0][1]; }'
+try 2 'int main() { int x[2][3]; int *y=x; y[2]=2; return x[0][2]; }'
+try 3 'int main() { int x[2][3]; int *y=x; y[3]=3; return x[1][0]; }'
+try 4 'int main() { int x[2][3]; int *y=x; y[4]=4; return x[1][1]; }'
+try 5 'int main() { int x[2][3]; int *y=x; y[5]=5; return x[1][2]; }'
+try 6 'int main() { int x[2][3]; int *y=x; y[6]=6; return x[2][0]; }'
+
 echo OK


### PR DESCRIPTION
## summary
- wrap `primary()` with `postfix()` to parse x[y].
- fix pointer add operation on `new_add()`.

## ref
- https://github.com/rui314/chibicc/commit/a0242d82cd818125010e8fa43f0efb935a306815
- https://www.sigbus.info/compilerbook#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9722-%E9%85%8D%E5%88%97%E3%81%AE%E6%B7%BB%E5%AD%97%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%99%E3%82%8B