### PR TITLE
update: read file instead of standard input

### DIFF
--- a/9cc.h
+++ b/9cc.h
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include <assert.h>
 #include <ctype.h>
+#include <errno.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -233,6 +234,7 @@ void gen(Node *node);
 
 /* main.c */
 
+char *filename;
 char *user_input;
 
 int main(int argc, char **argv);

--- a/main.c
+++ b/main.c
@@ -1,5 +1,27 @@
 #include "9cc.h"
 
+static char *read_file(char *path)
+{
+  FILE *fp = fopen(path, "r");
+  if (!fp)
+    error("cannot open %s: %s\n", path, strerror(errno));
+
+  if (fseek(fp, 0, SEEK_END) == -1)
+    error("%s: fseek: %s", path, strerror(errno));
+  size_t size = ftell(fp);
+  if (fseek(fp, 0, SEEK_SET) == -1)
+    error("%s: fseek: %s", path, strerror(errno));
+
+  char *buf = calloc(1, size + 2);
+  int res = fread(buf, size, 1, fp);
+
+  if (size == 0 || buf[size - 1] != '\n')
+    buf[size++] = '\n';
+  buf[size] = '\0';
+  fclose(fp);
+  return buf;
+}
+
 int align_to(int n, int align)
 {
   return (n + align - 1) & ~(align - 1);
@@ -10,7 +32,8 @@ int main(int argc, char **argv)
   if (argc != 2)
     error("%s: 引数の個数が正しくありません\n", argv[0]);
 
-  user_input = argv[1];
+  filename = argv[1];
+  user_input = read_file(filename);
   // トークナイズする
   token = tokenize();
   // デバッグ用

--- a/tokenize.c
+++ b/tokenize.c
@@ -13,10 +13,30 @@ void error(char *fmt, ...)
   exit(1);
 }
 
+// reports an error message in the following format and exit.
+// foo.c:10: x = y + 1;
+//               ^ <error message here>
 void verror_at(char *loc, char *fmt, va_list ap)
 {
-  int pos = loc - user_input;
-  fprintf(stderr, "%s\n", user_input);
+  // エラー箇所の行の開始地点と終了地点を取得する
+  char *line = loc;
+  while (user_input < line && line[-1] != '\n')
+    line--;
+
+  char *end = loc;
+  while (*end = '\n')
+    end++;
+
+  // エラー箇所が何行目かを調べる
+  int line_num = 1;
+  for (char *p = user_input; p < line; p++)
+    if (*p == '\n')
+      line_num++;
+
+  int indent = fprintf(stderr, "%s:%d: ", filename, line_num);
+  fprintf(stderr, "%.*s\n", (int)(end - line), line);
+
+  int pos = loc - line + indent;
   fprintf(stderr, "%*s", pos, "");
   fprintf(stderr, "^ ");
   vfprintf(stderr, fmt, ap);


### PR DESCRIPTION
## summary
- add `read_file` function to open a file and read its text.
- improve error message to support multi-line detection.

## ref
- https://github.com/rui314/chibicc/commit/64f2d0b8a7c0e629e96a7d96c6845d7284d91d05
- fseek / ftell should not be used for computing file size, but not sure what this explanation means...
https://wiki.sei.cmu.edu/confluence/display/c/FIO19-C.+Do+not+use+fseek%28%29+and+ftell%28%29+to+compute+the+size+of+a+regular+file
